### PR TITLE
fixed Makefile to compile on Ubuntu 16.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ OBJECTS=$(SOURCES:.c=.o)
 DOXYGEN=doxygen
 EXECUTABLE=sipbot
 
-all: 
-	$(CC) $(LDFLAGS) $(SOURCES) $(CFLAGS) -o $(EXECUTABLE)
+all:
+	$(CC) $(SOURCES) $(CFLAGS) -o $(EXECUTABLE) $(LDFLAGS)
 
 audio-tests:
-	$(CC) $(LDFLAGS) src/log.c src/law.c tests/test_wave.c src/filter.c $(CFLAGS) -o test_wave	
-	$(CC) -Wall -g -lpulse -lpulse-simple -lm tests/test_filter.c -o test_filter
-	$(CC) -Wall -g -lpulse -lpulse-simple -lm tests/test_downsample.c src/filter.c -o test_downsample
+	$(CC) src/log.c src/law.c tests/test_wave.c src/filter.c $(CFLAGS) -o test_wave $(LDFLAGS)
+	$(CC) -Wall -g tests/test_filter.c -o test_filter -lpulse -lpulse-simple -lm
+	$(CC) -Wall -g tests/test_downsample.c src/filter.c -o test_downsample -lpulse -lpulse-simple -lm
 
 doc:
 	$(DOXYGEN) DoxyFile


### PR DESCRIPTION
Nice project! One minor linking problem though: the linker complained about an undefined reference to `ortp_init' and many more, although the library is installed and the symbol is in there.

Placing the -l library statements at the end of the gcc commands did the trick for me, so if this still works for you, please consider merging this commit.